### PR TITLE
To import OneView in-situ nested folder datasets into hyperspy

### DIFF
--- a/OneViewIS_hyperspy_import.ipynb
+++ b/OneViewIS_hyperspy_import.ipynb
@@ -1,0 +1,209 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#This notebook imports Oneview in-situ data as a hyperspy stack"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib qt5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    import hyperspy.api as hs\n",
+    "    import numpy as np\n",
+    "    import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def OneView_IS_import(folder_path):\n",
+    "    \"\"\"\n",
+    "    Imports OneView_IS files.\n",
+    "    These files are saved as nested folders with the format:\n",
+    "    'Dataset/Hour_00/Minute_00/Second_00/*.dm4' etc.\n",
+    "    Function parameters:\n",
+    "    \n",
+    "    folder_path (string): the directory path of the Dataset folder\n",
+    "    ----------\n",
+    "    Retuns:\n",
+    "    imageStack_hs: Hypespy Signal2D lazy stack of the frames, ordered sequentially\n",
+    "                    The image axes parameters are copied over from first frame.\n",
+    "                    The thrid axis is defines as 't', scaled with the camera exposure time. \n",
+    "                    OneView_IS captures the frames continuously. \n",
+    "    \"\"\"\n",
+    "    \n",
+    "    os.chdir(folder_path)\n",
+    "    \n",
+    "    filenames_sort = []\n",
+    "    for root, dirs, files in os.walk(folder_path):\n",
+    "        for file in files:\n",
+    "            if file.endswith(\".dm4\") or file.endswith(\".dm3\"):\n",
+    "                filenames_sort.append(os.path.join(root, file))\n",
+    "                \n",
+    "    filenames_sort.sort()\n",
+    "    \n",
+    "    imageStack_hs = hs.load(filenames_sort, lazy = True, stack = True)\n",
+    "    \n",
+    "    imageStack_hs.axes_manager[0].name = 't'\n",
+    "    imageStack_hs.axes_manager[0].units = 'sec'\n",
+    "    imageStack_hs.axes_manager[0].scale = imageStack_hs.inav[0].metadata.Acquisition_instrument.TEM.Camera.exposure\n",
+    "    \n",
+    "    imageStack_hs.axes_manager['t'].index = 0 #For some reason the index is changed to 211! Resettting to 0 here\n",
+    "    \n",
+    "    return imageStack_hs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = OneView_IS_import(r'Z:\\Mohsen\\Yasser Sessions\\20180425-MD-CsPbBr3-Dose\\4- 80kV\\Dataset36')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<LazySignal2D, title: Second_00, dimensions: (470|1024, 1024)>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "table, th, td {\n",
+       "\tborder: 1px solid black;\n",
+       "\tborder-collapse: collapse;\n",
+       "}\n",
+       "th, td {\n",
+       "\tpadding: 5px;\n",
+       "}\n",
+       "</style>\n",
+       "<p><b>< Axes manager, axes: (470|1024, 1024) ></b></p>\n",
+       "<table style='width:100%'>\n",
+       "\n",
+       "<tr> \n",
+       "<th>Navigation axis name</th> \n",
+       "<th>size</th> \n",
+       "<th>index</th> \n",
+       "<th>offset</th> \n",
+       "<th>scale</th> \n",
+       "<th>units</th> </tr>\n",
+       "<tr> \n",
+       "<td>t</td> \n",
+       "<td>470</td> \n",
+       "<td>0</td> \n",
+       "<td>0.0</td> \n",
+       "<td>0.1</td> \n",
+       "<td>sec</td> </tr></table>\n",
+       "<table style='width:100%'>\n",
+       "\n",
+       "<tr> \n",
+       "<th>Signal axis name</th> \n",
+       "<th>size</th> \n",
+       "<th>offset</th> \n",
+       "<th>scale</th> \n",
+       "<th>units</th> </tr>\n",
+       "<tr> \n",
+       "<td>x</td> \n",
+       "<td>1024</td> \n",
+       "<td>-0.0</td> \n",
+       "<td>0.012026626616716385</td> \n",
+       "<td>1/nm</td> </tr>\n",
+       "<tr> \n",
+       "<td>y</td> \n",
+       "<td>1024</td> \n",
+       "<td>-0.0</td> \n",
+       "<td>0.012026626616716385</td> \n",
+       "<td>1/nm</td> </tr></table>\n"
+      ],
+      "text/plain": [
+       "<Axes manager, axes: (470|1024, 1024)>\n",
+       "            Name |   size |  index |  offset |   scale |  units \n",
+       "================ | ====== | ====== | ======= | ======= | ====== \n",
+       "               t |    470 |      0 |       0 |     0.1 |    sec \n",
+       "---------------- | ------ | ------ | ------- | ------- | ------ \n",
+       "               x |   1024 |        |      -0 |   0.012 |   1/nm \n",
+       "               y |   1024 |        |      -0 |   0.012 |   1/nm "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data.axes_manager"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data.save('Dataset36', extension = 'hdf5')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This sorts the frames using the timestamped file name and lazily imports as Signal2D stack into hyperspy.